### PR TITLE
Use the Decimal class for floating point math

### DIFF
--- a/basic.py
+++ b/basic.py
@@ -1,5 +1,5 @@
 import collections
-import math
+from decimal import Decimal
 
 from sly.lex import Lexer, Token
 from sly.yacc import Parser
@@ -58,13 +58,10 @@ class BasicLexer(Lexer):
             self.index
             and self.text[:token.index] != token.index * ' '
         ):
-            float_value = float(token.value)
-            int_value = int(float_value)
-            token.value = (
-                int_value
-                if math.isclose(int_value, float_value)
-                else float_value
-            )
+            if '.' not in token.value:
+                token.value = (int(token.value))
+            else:
+                token.value = (Decimal(token.value))
 
         else:
             if '.' not in token.value:
@@ -306,14 +303,6 @@ class BasicInterpreter:
 
         if isinstance(node, Expression):
             return_value = self.execute(*node)
-
-        if isinstance(return_value, float):
-            int_return_value = int(return_value)
-            return_value = (
-                int_return_value
-                if math.isclose(int_return_value, return_value)
-                else return_value
-            )
 
         return return_value
 

--- a/basic.py
+++ b/basic.py
@@ -30,6 +30,8 @@ class BasicLexer(Lexer):
         DIVIDE,
         EQUALS,
         COLON,
+        LPAREN,
+        RPAREN
     }
 
     ignore = ' '
@@ -40,6 +42,8 @@ class BasicLexer(Lexer):
     DIVIDE = r'/'
     EQUALS = r'='
     COLON = r':'
+    LPAREN = r'\('
+    RPAREN = r'\)'
 
     REM = r"(?:REM|').*"
     PRINT = r'PRINT'
@@ -198,6 +202,10 @@ class BasicParser(Parser):
     @_('MINUS expr %prec UNARY_MINUS')
     def expr(self, parsed):
         return Expression('negative', [parsed.expr])
+
+    @_('LPAREN expr RPAREN')
+    def expr(self, parsed):
+        return parsed.expr
 
     @_('expr PLUS expr')
     def expr(self, parsed):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -326,7 +326,8 @@ def test_conditionals(capsys, interpreter, expected_output):
     argvalues=(
         ('PRINT 3 + 5 * -2', '-7'),
         ('PRINT 3 - 4 * 5', '-17'),
-        ('PRINT 3 - 10 / 5', '1'),
+        ('PRINT 3 - 10 / 5', '1.0'),
+        ('PRINT 0.1 + 0.2', '0.3'),
     )
 )
 def test_extra_arithmetic(capsys, interpreter, expected_output):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -328,6 +328,9 @@ def test_conditionals(capsys, interpreter, expected_output):
         ('PRINT 3 - 4 * 5', '-17'),
         ('PRINT 3 - 10 / 5', '1.0'),
         ('PRINT 0.1 + 0.2', '0.3'),
+        ('PRINT (0.1 + 0.2) * 2', '0.6'),
+        ('PRINT (0.1 * 0.2) + 2', '2.02'),
+        ('PRINT ((0.1 * 0.2) + (0.24 * 2))', '0.50'),
     )
 )
 def test_extra_arithmetic(capsys, interpreter, expected_output):


### PR DESCRIPTION
Previously the interpreter used the float type for decimal calculations with all the rough edges of this data type.

By using Python decimal maths the deceptive 0.1 + 0.2 now equals 0.3 as humans intuitively expect.